### PR TITLE
MXEXP fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ cmake --build build
 The built programs are located in the `bin` directory inside the `build`
 directory.
 
-### Generating python wheel package
+### Building from source + generating python wheel package
 
 The python package is built using [poetry](https://python-poetry.org/). To build
 the python package just execute `poetry build` in the root directory of the

--- a/build.py
+++ b/build.py
@@ -52,15 +52,18 @@ def build(setup_kwargs: Dict[str, Any]) -> None:
     # Run targeted build separately as poetry does not support target builds yet
     try:
         setuptools.setup(
-            **setup_kwargs, 
-            script_args = ['bdist_wheel'],
-            options = { 
-                'bdist_wheel': { 'plat_name': os.getenv('PP_PYTHON_TARGET', get_platform()) },
-                'egg_info': { 'egg_base': './dist/' }
-            }
+            **setup_kwargs,
+            script_args=["bdist_wheel"],
+            options={
+                "bdist_wheel": {
+                    "plat_name": os.getenv("PP_PYTHON_TARGET", get_platform())
+                },
+                "egg_info": {"egg_base": "./dist/"},
+            },
         )
     except BaseException as e:
         distutils_log.error(f"Failed to create targeted wheel: {e}")
+
 
 def remove_files(target_dir: Path, pattern: str) -> None:
     """Delete files matched with a glob pattern in a directory tree."""
@@ -83,3 +86,7 @@ def copy_files(src_dir: Path, dest_dir: Path, pattern: str) -> None:
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dest)
             distutils_log.info(f"copied {src} to {dest}")
+
+
+if __name__ == "__main__":
+    build({})

--- a/src/mxexp/mataid.f
+++ b/src/mxexp/mataid.f
@@ -17,6 +17,8 @@
 *---  A is assumed here to be under the COOrdinates storage format.
 *
       integer n, nz, nzmax
+
+*---  nzmax must match all other instances of the RMAT common block 
       parameter( nzmax = 60000000 )
       integer ia(nzmax), ja(nzmax)
       double precision a(nzmax)
@@ -40,6 +42,8 @@
 *---  A is assumed to be under the Compress Row Storage (CRS) format.
 *
       integer n, nz, nzmax
+      
+*---  nzmax must match all other instances of the RMAT common block 
       parameter( nzmax = 60000000 )
       integer ia(nzmax), ja(nzmax)
       double precision a(nzmax)
@@ -63,6 +67,8 @@
 *---  A is assumed to be under the Compress Column Storage (CCS) format.
 *
       integer n, nz, nzmax
+      
+*---  nzmax must match all other instances of the RMAT common block 
       parameter( nzmax = 60000000 )
       integer ia(nzmax), ja(nzmax)
       double precision a(nzmax)

--- a/src/mxexp/mataid.f
+++ b/src/mxexp/mataid.f
@@ -40,7 +40,7 @@
 *---  A is assumed to be under the Compress Row Storage (CRS) format.
 *
       integer n, nz, nzmax
-      parameter( nzmax = 600000 )
+      parameter( nzmax = 60000000 )
       integer ia(nzmax), ja(nzmax)
       double precision a(nzmax)
       common /RMAT/ a, ia, ja, nz, n
@@ -63,7 +63,7 @@
 *---  A is assumed to be under the Compress Column Storage (CCS) format.
 *
       integer n, nz, nzmax
-      parameter( nzmax = 600000 )
+      parameter( nzmax = 60000000 )
       integer ia(nzmax), ja(nzmax)
       double precision a(nzmax)
       common /RMAT/ a, ia, ja, nz, n

--- a/src/mxexp/mxexp.f
+++ b/src/mxexp/mxexp.f
@@ -12,6 +12,8 @@
 *---  BEWARE: these values should match those in dgmatv.f
       integer n, nz, nmax, nzmax
       !parameter( nmax = 5000000, nzmax = 60000000 )
+      
+*---  nzmax must match all other instances of the RMAT common block 
       parameter( nmax =   500000, nzmax = 60000000 )
       integer ia(nzmax), ja(nzmax)
       double precision a(nzmax)
@@ -154,7 +156,7 @@ c---
 
 *---  set other input arguments ...
       nsteps = time/dt;
-      tol = 0.0d0
+      tol = 1d-17
       m = 30
       itrace = 0
 
@@ -170,7 +172,7 @@ c---
 
       t = 0;
       do i = 1,nsteps
-      call DGEXPV( n, m, dt,v,w, tol, anorm,
+        call DGEXPV( n, m, dt,v,w, tol, anorm,
      .             wsp,lwsp, iwsp,liwsp, dgcoov, itrace, iflag )
         do j = 1,n
           v(j) = w(j)

--- a/src/mxexp/mxexp.f
+++ b/src/mxexp/mxexp.f
@@ -12,7 +12,7 @@
 *---  BEWARE: these values should match those in dgmatv.f
       integer n, nz, nmax, nzmax
       !parameter( nmax = 5000000, nzmax = 60000000 )
-      parameter( nmax =   500000, nzmax = 6000000 )
+      parameter( nmax =   500000, nzmax = 60000000 )
       integer ia(nzmax), ja(nzmax)
       double precision a(nzmax)
       common /RMAT/ a, ia, ja, nz, n


### PR DESCRIPTION
Fixing an issue where the mxexp program would fail to calculate anything at all, as a very central common block was being declared with differently sized arrays.